### PR TITLE
super-tiny refactoring

### DIFF
--- a/lib/ephemeral/collection.rb
+++ b/lib/ephemeral/collection.rb
@@ -19,8 +19,8 @@ module Ephemeral
 
     def where(args={})
       return [] unless self.objects
-      results = args.inject([]){|a,kv| a << self.objects.select{|o| o.send(kv[0]) == kv[1]}}
-      results = results.flatten.select{|r| results.flatten.count(r) == results.count}.uniq
+      results = args.inject([]) {|a, (k, v)| a << self.objects.select {|o| o.send(k) == v} }
+      results = results.flatten.select {|r| results.flatten.count(r) == results.count }.uniq
     end
 
     def last
@@ -35,8 +35,8 @@ module Ephemeral
 
     def execute_scope(method)
       return Ephemeral::Collection.new(self.klass.name) unless self.objects
-      results = self.klass.scopes[method].inject([]){|a,kv| a << self.objects.select{|o| o.send(kv[0]) == kv[1]}}
-      results = results.flatten.select{|r| results.flatten.count(r) == results.count}.uniq
+      results = self.klass.scopes[method].inject([]) {|a, (k, v)| a << self.objects.select {|o| o.send(k) == v } }
+      results = results.flatten.select {|r| results.flatten.count(r) == results.count }.uniq
       Ephemeral::Collection.new(self.klass.name, results)
     end
 


### PR DESCRIPTION
use 

``` ruby
foo.inject([]) {|a, (k,v)| k; v }
```

instead of

``` ruby
foo.inject([]) {|a, kv| kv[0]; kv[1] }
```
